### PR TITLE
fix: insert close-paran with weird indent and comments

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -802,6 +802,26 @@ export default class NodePatcher {
 
 
   /**
+   * Gets the last index of the token between source locations that matches a
+   * predicate function.
+   */
+  indexOfLastSourceTokenBetweenSourceIndicesMatching(right: number, left: number, predicate: (token: SourceToken) => boolean): ?SourceTokenListIndex {
+    let tokenList = this.getProgramSourceTokens();
+    return tokenList.lastIndexOfTokenMatchingPredicate(
+      token => {
+        return (
+          token.start >= left &&
+          token.start <= right &&
+          predicate(token)
+        );
+      },
+      tokenList.indexOfTokenNearSourceIndex(right),
+      tokenList.indexOfTokenNearSourceIndex(left).previous()
+    );
+  }
+
+
+  /**
    * Gets the token at a particular index.
    */
   sourceTokenAtIndex(index: SourceTokenListIndex): ?SourceToken {

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -89,7 +89,11 @@ export default class FunctionApplicationPatcher extends NodePatcher {
       // this case by moving the `.` to be right after the new `)`.
       let nextSemanticToken = this.getFirstSemanticToken(this.contentEnd);
       if (nextSemanticToken && nextSemanticToken.type === SourceType.DOT) {
-        this.overwrite(this.outerEnd, nextSemanticToken.start, ')');
+        let lfPosTok = this.indexOfLastSourceTokenBetweenSourceIndicesMatching(nextSemanticToken.start, this.contentEnd,
+          t => t.type === SourceType.NEWLINE
+        );
+        let lfPos = this.sourceTokenAtIndex(lfPosTok);
+        this.insert(lfPos.end, ')');
       } else {
         this.insert(this.contentEnd, `\n${this.getIndent()})`);
       }

--- a/test/member_access_test.js
+++ b/test/member_access_test.js
@@ -133,7 +133,7 @@ describe('member access', () => {
           
          .then
     `, `
-      Q(() => P(() => foo).then
+      Q(() => P(() => foo)   .then
        );
     `);
   });
@@ -145,7 +145,8 @@ describe('member access', () => {
         .d
     `, `
       a(b(
-        c)).d;
+        c)
+      )  .d;
     `);
   });
 
@@ -158,7 +159,22 @@ describe('member access', () => {
     `, `
       a
         .b(c(d,
-          e)).f;
+          e)
+      )  .f;
+    `);
+  });
+
+  it('handles a complex implicit call wrapping a multiline function call with inline comment and followed by a dot', () => {
+    check(`
+      a
+        .b c(d,
+          e) #giri
+        .f
+    `, `
+      a
+        .b(c(d,
+          e) //giri
+      )  .f;
     `);
   });
 });


### PR DESCRIPTION
Insert after last NEWLINE, no need to `overwrite`